### PR TITLE
Selectively enable dispatch on kBatchedKey

### DIFF
--- a/functorch/csrc/BatchRulesLinearAlgebra.cpp
+++ b/functorch/csrc/BatchRulesLinearAlgebra.cpp
@@ -40,8 +40,6 @@ std::tuple<Tensor, optional<int64_t>> dot_batch_rule(const Tensor& A, optional<i
   auto B_ = moveBatchDimToFront(B, B_bdim);
   if (A_bdim && B_bdim) {
     return std::make_tuple(at::matmul(A_.unsqueeze(-2), B_.unsqueeze(-1)).squeeze(-1).squeeze(-1), 0);
-  } else if (!A_bdim && !B_bdim) {
-    return std::make_tuple(at::dot(A_, B_), nullopt);
   } else {
     return std::make_tuple(at::matmul(A_, B_.t()), 0);
   }

--- a/test/test_vmap.py
+++ b/test/test_vmap.py
@@ -932,6 +932,18 @@ class TestVmapAPI(TestCase):
         y = reshape_dim_outof(-1, 6, x)
         self.assertEqual(y, x.reshape(12, 12, 6, 2))
 
+    def test_batch_rule_does_not_need_to_handle_no_batched_input(self):
+        def f(x, y):
+            res = torch.dot(y, torch.ones(2))
+            return x + res
+
+        x = torch.randn(7, 5)
+        y = torch.randn(3, 2)
+        out = vmap(vmap(f, in_dims=(0, None)), in_dims=(None, 0))(x, y)
+        expected = torch.mv(y, torch.ones(2)).view(3, 1, 1) + x
+        self.assertEqual(out, expected)
+
+
 def slice_inputs(inputs, bdims, i):
     result = []
     for inp, bdim in zip(inputs, bdims):


### PR DESCRIPTION
This PR makes it so that dispatch on kBatchedKey only can happen if there are
tensors batched at the current level. Otherwise, kBatchedKey is excluded
(even if there are BatchedTensors!).

To find tensors batched at the current level, we check:
- all tensor arguments
- we peek into all TensorLists
- we peek into all Tensor?[].
the above bullet points should be sufficient.

Dispatch for kVmapModeKey is not affected.

Test Plan:
- run all tests