### PR TITLE
(Grad)TensorWrapper sometimes has storage (and data_ptr)

### DIFF
--- a/functorch/csrc/TensorWrapper.h
+++ b/functorch/csrc/TensorWrapper.h
@@ -46,6 +46,11 @@ struct TORCH_API TensorWrapper : public c10::TensorImpl {
       bool allow_tensor_metadata_change) const override;
   void shallow_copy_from(const c10::intrusive_ptr<TensorImpl>& impl) override;
 
+  // See Note [TensorWrapper sometimes has storage]
+  bool storage_access_should_throw() {
+    return hacky_storage_access_should_throw_;
+  }
+
  private:
   const char* tensorimpl_type_name() const override;
   Tensor value_;
@@ -56,6 +61,9 @@ struct TORCH_API TensorWrapper : public c10::TensorImpl {
   // 1) May still have autograd metadata on them
   // 2) Forward dispatches to the underlying value()
   std::shared_ptr<bool> is_alive_;
+
+  // Note [TensorWrapper sometimes has storage]
+  bool hacky_storage_access_should_throw_ = false;
 };
 
 TORCH_API Tensor makeTensorWrapper(const Tensor& tensor, int64_t level);

--- a/test/test_eager_transforms.py
+++ b/test/test_eager_transforms.py
@@ -463,7 +463,6 @@ class TestGradTransform(TestCase):
         result = grad(f2)(x)
         self.assertEqual(result, (x <= 0).type_as(x))
 
-    @unittest.expectedFailure
     def test_tensor_ctor_inside_grad(self, device):
         def foo(x):
             return x * torch.tensor(2., device=device)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -136,12 +136,10 @@ def is_inplace(op, variant):
 
 
 vjp_fail = {
-    '__getitem__',
-    '__rpow__',
     'linalg.cholesky',
     'linalg.inv',
-    'linalg.matrix_norm',
     'linalg.matrix_power',
+    'linalg.matrix_norm',
     'linalg.norm',
     'nanquantile',
     'quantile',
@@ -216,7 +214,8 @@ class TestOperators(TestCase):
             result = fn(*primals)
             cotangents = tree_map(lambda x: torch.randn_like(x), result)
 
-            _, vjp_fn = vjp(fn, *primals)
+            out, vjp_fn = vjp(fn, *primals)
+            self.assertEqual(out, result)
             result_vjps = vjp_fn(cotangents)
 
             _, vjp_fn = ref_vjp(fn, *primals)


### PR DESCRIPTION
TensorWrapper can have storage now:
- Case 1: If it wraps a tensor with storage, it will have storage
- Case 2: If it wraps a tensor without storage, it will not have storage

The rationale for this is to fix #7. When torch.tensor gets called, the
following happens:
- at::empty gets called
- some data from a PyObject* gets written directly into the new empty
tensor

The previous problem was that `at::empty` would return a TensorWrapper
wrapping a regular Tensor and that TensorWrapper did not have
storage/data_ptr.

It should be fine that TensorWrapper sometimes has storage. Users should
not write directly to the .data_ptr (because that would cause gradients
to be incorrect, but it is the same in regular PyTorch).

Test Plan:
- wait for tests