### PR TITLE
Adds one_hot decomposition, scatter batch rule

### DIFF
--- a/test/test_vmap.py
+++ b/test/test_vmap.py
@@ -2542,6 +2542,14 @@ class TestVmapOperators(Namespace.TestVmapBase):
             for loop_out, batched_out in get_fallback_and_vmap_exhaustive(conv_fn, arg_values, kwarg_values):
                 self.assertEqual(loop_out, batched_out)
 
+    def test_one_hot(self):
+        sample_inputs = [
+            (torch.randint(0, 3, []), 3),
+            (torch.randint(0, 3, [2, 3, 4]), 4),
+        ]
+        for args in sample_inputs:
+            for loop_out, batched_out in get_fallback_and_vmap_exhaustive(F.one_hot, args, {}):
+                self.assertEqual(loop_out, batched_out)
 
     def test_mode_key(self):
         def vmap_f(x):


### PR DESCRIPTION
The one hot decomposition is a quick hack for #85. I think we might
want to make one_hot a primitive w.r.t. autograd because of the
data-dependent error checking.

Test Plan:
- wait for CI