### PR TITLE
Specialization cache

### DIFF
--- a/test/test_pythonkey.py
+++ b/test/test_pythonkey.py
@@ -97,6 +97,23 @@ class TestPythonKey(TestCase):
         inp = torch.randn(3)
         self.assertEqual(jit_f(inp), f(inp))
 
+    def test_nnc_jit_warns_on_recompilation(self, device):
+        def f(x):
+            return torch.sin(x)
+
+        jit_f = nnc_jit(f)
+
+        inp = torch.randn(3)
+        jit_f(inp)
+        inp2 = torch.randn(5)
+
+        with warnings.catch_warnings(record=True) as warns:
+            warnings.simplefilter("always")
+            jit_f(inp2)
+
+        self.assertEqual(len(warns), 1)
+        self.assertTrue("Recompiling" in str(warns[-1].message))
+
     def test_nnc_scalar(self, device):
         def f(x):
             return torch.sin(x)


### PR DESCRIPTION
Benchmark:
https://gist.github.com/zou3519/f7691a94f8570b27cccc8e16fc8ed13b

It doesn't look like this adds a lot of overhead. If the overhead
becomes a problem we can move this into C++.

The cache works by specializing on shape/stride/dtype/device of the
input tensor and any concrete values.

NB: the concrete value cache means that if an integer arg to the
function changes, we will recompile. In the future, when we add
static_argnums, we should change the cache to "not specialize on
specific integers".

Test Plan:
- run tests