### PR TITLE
Ported `_reshape_alias` to the new API

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,7 @@ if __name__ == '__main__':
         name=package_name,
         version=version,
         author='PyTorch Core Team',
-        url="https://github.com/zou3519/functorch",
+        url="https://github.com/facebookresearch/functorch",
         description='prototype of composable function transforms for PyTorch',
         license='BSD',
 


### PR DESCRIPTION
Description:
- Tried to port `_reshape_alias` to the new API. Algorithm is not exactly the same as in the old method, maybe unsafe ?

cc @zou3519 