### PR TITLE
Revert "Ported `view` op to the new API"

### DIFF
--- a/functorch/csrc/BatchRulesViews.cpp
+++ b/functorch/csrc/BatchRulesViews.cpp
@@ -272,33 +272,15 @@ std::tuple<Tensor, optional<int64_t>> select_batching_rule(const Tensor& self, o
   return std::make_tuple(result, 0);
 }
 
-VmapDimVector getPhysicalShape(const Tensor& self, int64_t & bdim, const IntArrayRef logical_shape) {
-  VmapDimVector new_shape = { logical_shape.begin(), logical_shape.end() };
-  if (bdim >= new_shape.size()) {
-    bdim = new_shape.size();
-  }
-  new_shape.insert(new_shape.begin() + bdim, self.size(bdim));
-  return new_shape;
-}
-
 std::tuple<Tensor, optional<int64_t>> _reshape_alias_batch_rule(const Tensor& self, optional<int64_t> bdim, const IntArrayRef shape, const IntArrayRef strides) {
   (void) strides;
   TORCH_INTERNAL_ASSERT(bdim.has_value());
-  // bdim_ can be updated by getPhysicalShape
-  int64_t bdim_ = *bdim;
-  auto new_shape = getPhysicalShape(self, bdim_, shape);
-  return std::make_tuple(at::reshape(self, new_shape), bdim_);
-}
 
-std::tuple<Tensor, optional<int64_t>> view_batch_rule(const Tensor& self, optional<int64_t> bdim, const IntArrayRef size) {
-  if (!bdim.has_value()) {
-    // expand_as can route to this batching rule with unbatched tensor
-    return std::make_tuple(self.view(size), bdim);
-  }
-  // bdim_ can be updated by getPhysicalShape
-  int64_t bdim_ = *bdim;
-  auto new_size = getPhysicalShape(self, bdim_, size);
-  return std::make_tuple(self.view(new_size), bdim_);
+  c10::SmallBuffer<int64_t, 5> new_shape(shape.size() + 1);
+  new_shape[*bdim] = self.size(*bdim);
+  std::copy(shape.begin(), shape.begin() + *bdim, new_shape.begin());
+  std::copy(shape.begin() + *bdim, shape.end(), new_shape.begin() + *bdim + 1);
+  return std::make_tuple(at::reshape(self, new_shape), bdim);
 }
 
 std::tuple<Tensor,optional<int64_t>> diagonal_backward_batch_rule(
@@ -357,7 +339,6 @@ TORCH_LIBRARY_IMPL(aten, FT_BATCHED_KEY, m) {
   VMAP_SUPPORT("squeeze", squeeze_batch_rule);
   VMAP_SUPPORT("squeeze.dim", squeeze_dim_batch_rule);
   VMAP_SUPPORT("_reshape_alias", _reshape_alias_batch_rule);
-  VMAP_SUPPORT("view", view_batch_rule);
   VMAP_SUPPORT("diagonal_backward", diagonal_backward_batch_rule);
   VMAP_SUPPORT("select_backward", select_backward_batch_rule);
   VMAP_SUPPORT("slice_backward", slice_backward_batch_rule);

--- a/test/test_vmap.py
+++ b/test/test_vmap.py
@@ -2432,6 +2432,10 @@ class TestVmapOperators(Namespace.TestVmapBase):
         B0, B1, B2 = 7, 11, 13
         op = torch.Tensor.view
 
+        # We should error out if the view would produce an incorrect result
+        with self.assertRaises(RuntimeError):
+            vmap(op, in_dims=(1, None))(torch.rand(2, B0, 5), [10])
+
         test(op, (torch.rand(B0, 2 * 5), [2, 5]), in_dims=(0, None))
         test(op, (torch.rand(B0, 4, 5), [1, 2, 1, 10]), in_dims=(0, None))
         test(vmap(lambda t: t.view([-1])), (torch.rand(B0, B1, 2, 5, 3),))
@@ -2442,6 +2446,10 @@ class TestVmapOperators(Namespace.TestVmapBase):
         test = self._vmap_view_test
         B0, B1, B2 = 7, 11, 13
         op = torch.Tensor.view_as
+
+        # We should error out if the view would produce an incorrect result
+        with self.assertRaises(RuntimeError):
+            vmap(op, in_dims=(1, 0))(torch.rand(2, B0, 5), torch.rand(B0, 10))
 
         test(op, (torch.rand(B0, 2 * 5), torch.rand(B0, 2, 5)))
         test(op, (torch.rand(2 * 5), torch.rand(B0, 2, 5)), in_dims=(None, 0))


### PR DESCRIPTION
Reverts facebookresearch/functorch#137

View batch rule implementation is wrong, let's revert the PR