### PR TITLE
{log|softmax}_backward update as per the new signature

### DIFF
--- a/functorch/csrc/BatchRulesReduceOps.cpp
+++ b/functorch/csrc/BatchRulesReduceOps.cpp
@@ -215,6 +215,12 @@ std::tuple<Tensor,optional<int64_t>> _softmax_backward_batch_rule(
       grad_output_, grad_output_bdim.has_value(),
       output_, output_bdim.has_value());
 
+  // Scalar tensor case. softmax turns into the identity when this happens.
+  // I don't know why the output is zeros, though, but that's what softmax tells me...
+  if (output_.dim() == 1 && (dim == 0 || dim == -1)) {
+    return std::make_tuple(at::zeros_like(grad_output_), 0);
+  }
+
   dim = getPhysicalDim(output_, /*has_batch_dim*/true, dim);
 
   // Not sure why output_ needs to be marked as .contiguous(). Someting must
@@ -239,6 +245,12 @@ std::tuple<Tensor,optional<int64_t>> _log_softmax_backward_batch_rule(
   std::tie(grad_output_, output_) = expand_bdims(
       grad_output_, grad_output_bdim.has_value(),
       output_, output_bdim.has_value());
+
+  // Scalar tensor case. softmax turns into the identity when this happens.
+  // I don't know why the output is zeros, though, but that's what softmax tells me...
+  if (output_.dim() == 1 && (dim == 0 || dim == -1)) {
+    return std::make_tuple(at::zeros_like(grad_output_), 0);
+  }
 
   dim = getPhysicalDim(output_, /*has_batch_dim*/true, dim);
 

--- a/functorch/csrc/BatchRulesReduceOps.cpp
+++ b/functorch/csrc/BatchRulesReduceOps.cpp
@@ -202,7 +202,6 @@ std::tuple<Tensor,optional<int64_t>> _softmax_backward_batch_rule(
     const Tensor& output, optional<int64_t> output_bdim,
     int64_t dim,
     ScalarType input_dtype) {
-  // NB: self only gets used for its dtype. We handle it anyways just in case.
   // softmax_backward's decomposition is y * gy - y * (y * gy).sum(dim, keepdim=True)
   // NB: the CUDA kernel handles strides so we can just expand
   // all of the tensors and call it a day. The CPU kernel is not as good but
@@ -246,8 +245,7 @@ std::tuple<Tensor,optional<int64_t>> _log_softmax_backward_batch_rule(
       grad_output_, grad_output_bdim.has_value(),
       output_, output_bdim.has_value());
 
-  // Scalar tensor case. softmax turns into the identity when this happens.
-  // I don't know why the output is zeros, though, but that's what softmax tells me...
+  // Scalar tensor case. log_softmax returns zeros when this happens
   if (output_.dim() == 1 && (dim == 0 || dim == -1)) {
     return std::make_tuple(at::zeros_like(grad_output_), 0);
   }

--- a/functorch/csrc/BatchRulesReduceOps.cpp
+++ b/functorch/csrc/BatchRulesReduceOps.cpp
@@ -181,33 +181,27 @@ Tensor dist_decomp(const Tensor& self, const Tensor& other, const Scalar& p) {
   return at::norm((self - other), p);
 }
 
-static std::tuple<Tensor, Tensor, Tensor> expand_bdims(
+static std::tuple<Tensor, Tensor> expand_bdims(
     const Tensor& a, bool a_has_bdim,
-    const Tensor& b, bool b_has_bdim,
-    const Tensor& c, bool c_has_bdim) {
+    const Tensor& b, bool b_has_bdim) {
   Tensor flagpole;
   if (a_has_bdim) {
     flagpole = a;
   } else if (b_has_bdim) {
     flagpole = b;
-  } else if (c_has_bdim) {
-    flagpole = c;
   } else {
     TORCH_INTERNAL_ASSERT(false);
   }
   return std::make_tuple(
       a_has_bdim ? a : a.expand_as(flagpole),
-      b_has_bdim ? b : b.expand_as(flagpole),
-      c_has_bdim ? c : c.expand_as(flagpole));
+      b_has_bdim ? b : b.expand_as(flagpole));
 }
 
 std::tuple<Tensor,optional<int64_t>> _softmax_backward_batch_rule(
     const Tensor& grad_output, optional<int64_t> grad_output_bdim,
     const Tensor& output, optional<int64_t> output_bdim,
     int64_t dim,
-    const Tensor& self, optional<int64_t> self_bdim) {
-  TORCH_INTERNAL_ASSERT(!(output_bdim.has_value() ^ self_bdim.has_value()),
-    "output_bdim and self_bdim must be the same");
+    ScalarType input_dtype) {
   // NB: self only gets used for its dtype. We handle it anyways just in case.
   // softmax_backward's decomposition is y * gy - y * (y * gy).sum(dim, keepdim=True)
   // NB: the CUDA kernel handles strides so we can just expand
@@ -215,34 +209,24 @@ std::tuple<Tensor,optional<int64_t>> _softmax_backward_batch_rule(
   // idk if the perf on that really matters
   auto grad_output_ = moveBatchDimToFront(grad_output, grad_output_bdim);
   auto output_ = moveBatchDimToFront(output, output_bdim);
-  auto self_ = moveBatchDimToFront(self, self_bdim);
 
   // Expand out that extra dimension for everyone
-  std::tie(grad_output_, output_, self_) = expand_bdims(
+  std::tie(grad_output_, output_) = expand_bdims(
       grad_output_, grad_output_bdim.has_value(),
-      output_, output_bdim.has_value(),
-      self_, self_bdim.has_value());
+      output_, output_bdim.has_value());
 
-  // Scalar tensor case. softmax turns into the identity when this happens.
-  // I don't know why the output is zeros, though, but that's what softmax tells me...
-  if (self_.dim() == 1 && (dim == 0 || dim == -1)) {
-    return std::make_tuple(at::zeros_like(grad_output_), 0);
-  }
-
-  dim = getPhysicalDim(self_, /*has_batch_dim*/true, dim);
+  dim = getPhysicalDim(output_, /*has_batch_dim*/true, dim);
 
   // Not sure why output_ needs to be marked as .contiguous(). Someting must
   // have changed in PyTorch (and output of softmax is probably always contiguous)
-  return std::make_tuple(at::_softmax_backward_data(grad_output_, output_.contiguous(), dim, self_), 0);
+  return std::make_tuple(at::_softmax_backward_data(grad_output_, output_.contiguous(), dim, input_dtype), 0);
 }
 
 std::tuple<Tensor,optional<int64_t>> _log_softmax_backward_batch_rule(
     const Tensor& grad_output, optional<int64_t> grad_output_bdim,
     const Tensor& output, optional<int64_t> output_bdim,
     int64_t dim,
-    const Tensor& self, optional<int64_t> self_bdim) {
-  TORCH_INTERNAL_ASSERT(!(output_bdim.has_value() ^ self_bdim.has_value()),
-    "output_bdim and self_bdim must be the same");
+    c10::ScalarType input_dtype) {
   // NB: It turns out that expanding + calling log_softmax_backward is generally
   // faster than the decomposition.
   // Benchmark here: https://gist.github.com/zou3519/ae3b33b5730a84aae8a80a05c89e078a
@@ -250,22 +234,15 @@ std::tuple<Tensor,optional<int64_t>> _log_softmax_backward_batch_rule(
   // We can squeeze out a last mile of performance by writing custom kernels.
   auto grad_output_ = moveBatchDimToFront(grad_output, grad_output_bdim);
   auto output_ = moveBatchDimToFront(output, output_bdim);
-  auto self_ = moveBatchDimToFront(self, self_bdim);
 
   // Expand out that extra dimension for everyone
-  std::tie(grad_output_, output_, self_) = expand_bdims(
+  std::tie(grad_output_, output_) = expand_bdims(
       grad_output_, grad_output_bdim.has_value(),
-      output_, output_bdim.has_value(),
-      self_, self_bdim.has_value());
+      output_, output_bdim.has_value());
 
-  // Scalar tensor case. log_softmax returns zeros when this happens
-  if (self_.dim() == 1 && (dim == 0 || dim == -1)) {
-    return std::make_tuple(at::zeros_like(grad_output_), 0);
-  }
+  dim = getPhysicalDim(output_, /*has_batch_dim*/true, dim);
 
-  dim = getPhysicalDim(self_, /*has_batch_dim*/true, dim);
-
-  return std::make_tuple(at::_log_softmax_backward_data(grad_output_, output_, dim, self_), 0);
+  return std::make_tuple(at::_log_softmax_backward_data(grad_output_, output_, dim, input_dtype), 0);
 }
 
 TORCH_LIBRARY_IMPL(aten, FT_BATCHED_KEY, m) {

--- a/functorch/csrc/OutOfPlacePlumbing.cpp
+++ b/functorch/csrc/OutOfPlacePlumbing.cpp
@@ -1643,11 +1643,11 @@ Tensor lowerToNextLayer<batch_rule_75_t,Tensor,const Tensor &, Dimname, c10::opt
   return makeBatched(std::get<0>(results), std::get<1>(results), cur_level);
 }
 
-typedef std::tuple<Tensor,c10::optional<int64_t>> (*batch_rule_76_t)(const Tensor &, c10::optional<int64_t>, const Tensor &, c10::optional<int64_t>, int64_t, const Tensor &, c10::optional<int64_t>);
+typedef std::tuple<Tensor,c10::optional<int64_t>> (*batch_rule_76_t)(const Tensor &, c10::optional<int64_t>, const Tensor &, c10::optional<int64_t>, int64_t, ScalarType);
 template <>
-Tensor lowerToNextLayer<batch_rule_76_t,Tensor,const Tensor &, const Tensor &, int64_t, const Tensor &>(
+Tensor lowerToNextLayer<batch_rule_76_t,Tensor,const Tensor &, const Tensor &, int64_t, ScalarType>(
   batch_rule_76_t batch_rule,
-  const Tensor & grad_output, const Tensor & output, int64_t dim, const Tensor & self
+  const Tensor & grad_output, const Tensor & output, int64_t dim, ScalarType input_dtype
 ) {
   c10::impl::ExcludeDispatchKeyGuard guard(kBatchedKey);
   auto maybe_layer = maybeCurrentDynamicLayer();
@@ -1659,10 +1659,7 @@ Tensor lowerToNextLayer<batch_rule_76_t,Tensor,const Tensor &, const Tensor &, i
   Tensor output_value;
   optional<int64_t> output_bdim;
   std::tie(output_value, output_bdim) = unwrapTensorAtLevel(output, cur_level);
-  Tensor self_value;
-  optional<int64_t> self_bdim;
-  std::tie(self_value, self_bdim) = unwrapTensorAtLevel(self, cur_level);
-  auto results = batch_rule(grad_output_value, grad_output_bdim, output_value, output_bdim, dim, self_value, self_bdim);
+  auto results = batch_rule(grad_output_value, grad_output_bdim, output_value, output_bdim, dim, input_dtype);
   return makeBatched(std::get<0>(results), std::get<1>(results), cur_level);
 }
 


### PR DESCRIPTION
functorch was failing when trying to run on the latest PyTorch.

This [PR](https://github.com/pytorch/pytorch/pull/65242) changed the signature of `softmax` and `logsoftmax` backward functions and hence there was a failure while Registering.

I think this will pass once the nightly with changes from this PR is pulled by the CI.
