### PR TITLE
Re-land the compile cache

### DIFF
--- a/benchmarks/operator_authoring.py
+++ b/benchmarks/operator_authoring.py
@@ -1,0 +1,260 @@
+from functools import partial
+import numpy as np
+import pandas as pd
+import timeit
+import torch
+from functorch import pointwise_operator
+
+WRITE_CSV = False
+CUDA = False
+SIZES = [1, 512, 8192]
+NUMBER = [100, 10, 1, 1]
+REPEAT = 20
+
+
+@pointwise_operator
+def nnc_add(a, b):
+    return a + b
+
+
+@pointwise_operator
+def nnc_addnorm(a, b, mean, std):
+    return (a + b - mean) / std
+
+
+def eager_addnorm(a, b, mean, std):
+    return (a + b - mean) / std
+
+
+def inplace_addnorm(a, b, mean, std, out):
+    out = torch.add(a, b, out=out)
+    torch.sub(out, mean, out=out)
+    torch.div(out, std, out=out)
+    return out
+
+
+ts_addnorm = torch.jit.script(eager_addnorm)
+ts_ip_addnorm = torch.jit.script(inplace_addnorm)
+
+
+def maybe_synced(fn):
+    if CUDA:
+        synchronize = torch.cuda.synchronize
+        synchronize()  # warmup
+
+        def _fn():
+            result = fn()
+            synchronize()
+            return result
+
+        return _fn
+    return fn
+
+
+def benchmark_loop(setup):
+    result = np.zeros((REPEAT, len(SIZES), 2), dtype=np.float64)
+    for s, n in enumerate(SIZES):
+        nnc, aten = setup(n)
+        nnc = maybe_synced(nnc)
+        aten = maybe_synced(aten)
+
+        for r in range(result.shape[0]):
+            result[r, s, 0] = timeit.timeit(nnc, number=NUMBER[s])
+            result[r, s, 1] = timeit.timeit(aten, number=NUMBER[s])
+
+    result = np.median(result, axis=0)
+    assert result.shape == (len(SIZES), 2)
+    result = result[:, 1] / result[:, 0]
+    print(result)
+    return result
+
+
+def test(make_args, nnc=nnc_add, aten=torch.add):
+    def setup(n):
+        args = make_args(n)
+        result_aten = aten(*args)
+        result_nnc = nnc(*args)
+        assert result_nnc.dtype == result_aten.dtype
+        assert result_nnc.size() == result_aten.size()
+        assert result_nnc.stride() == result_aten.stride()
+        torch.testing.assert_allclose(result_aten, result_nnc)
+        return (lambda: nnc(*args), lambda: aten(*args))
+
+    return benchmark_loop(setup)
+
+
+def test_inplace(make_args, nnc=nnc_add, aten=torch.add):
+    def inplace_setup(n):
+        a, b = make_args(n)
+        result_aten = torch.clone(a)
+        result_nnc = torch.clone(a)
+        nnc(result_nnc, b, out=result_nnc)
+        aten(result_aten, b, out=result_aten)
+        torch.testing.assert_allclose(result_aten, result_nnc)
+        return (lambda: nnc(a, b, out=a), lambda: aten(a, b, out=a))
+
+    return benchmark_loop(inplace_setup)
+
+
+def test_out(make_args, out, nnc=nnc_add, aten=torch.add):
+    def out_setup(n):
+        args = make_args(n)
+        result_aten = out(n)
+        result_nnc = out(n)
+        aten(*args, out=result_aten)
+        nnc(*args, out=result_nnc)
+        torch.testing.assert_allclose(result_aten, result_nnc)
+        result = out(n)
+        return (lambda: nnc(*args, out=result), lambda: aten(*args, out=result))
+
+    return benchmark_loop(out_setup)
+
+
+def test_backwards(make_args, nnc=nnc_add, aten=torch.add):
+    def backwards_setup(n):
+        args = make_args(n)
+        (grad_var,) = [a for a in args if a.requires_grad]
+        aten(*args).sum().backward()
+        correct = grad_var.grad.clone()
+        grad_var.grad.zero_()
+        nnc(*args).sum().backward()
+        torch.testing.assert_allclose(correct, grad_var.grad)
+        return (
+            lambda: nnc(*args).sum().backward(),
+            lambda: aten(*args).sum().backward(),
+        )
+
+    return benchmark_loop(backwards_setup)
+
+
+def main():
+    torch.set_num_threads(1)  # TODO(jansel): add parallel support
+    torch._C._jit_override_can_fuse_on_cpu(True)
+
+    device = "cuda" if CUDA else "cpu"
+    I = partial(torch.randint, 0, 100, device=device)
+    R = partial(torch.randn, device=device)
+
+    results = [
+        ("add", test(lambda n: (R(n, n), R(n, n)))),
+        ("broadcast1", test(lambda n: (R(n, n), R(1)))),
+        ("broadcast2", test(lambda n: (R(n, n), R(n, 1)))),
+        ("broadcast3", test(lambda n: (R(n, 1), R(1, n)))),
+        ("inplace", test_inplace(lambda n: (R(n, n), R(n, 1)))),
+        ("out=", test_out(lambda n: (R(n, n), R(n, n)), out=lambda n: R(n, n))),
+        ("transposed1", test(lambda n: (R(n, n), R(n, n).transpose(0, 1)))),
+        (
+            "transposed2",
+            test(lambda n: (R(n, n).transpose(0, 1), R(n, n).transpose(0, 1))),
+        ),
+        ("slice1", test(lambda n: (R(n + 1, n + 1, 2)[:n, :n, 0], R(n, n)))),
+        ("slice2", test(lambda n: (R(n, n, 2)[:, :, 0], R(n, n, 2)[:, :, 0]))),
+        (
+            "strided out",
+            test_out(
+                lambda n: (R(n, n), R(n, n)),
+                out=lambda n: R(n + 1, n + 1, 2)[:n, :n, 0],
+            ),
+        ),
+        (
+            "out convert",
+            test_out(
+                lambda n: (R(n, n), R(n, n)), out=lambda n: R(n, n, dtype=torch.float64)
+            ),
+        ),
+        ("issue #57611 (n,32,32,2)", test(lambda n: (R(1, 32, 32, 2), R(n, 1, 1, 2)))),
+        ("float+double", test(lambda n: (R(n, n), R(n, n, dtype=torch.float64)))),
+        (
+            "int+long",
+            test(
+                lambda n: (I([n, n], dtype=torch.int32), I([n, n], dtype=torch.int64))
+            ),
+        ),
+        (
+            "int+short",
+            test(
+                lambda n: (I([n, n], dtype=torch.int32), I([n, n], dtype=torch.int16))
+            ),
+        ),
+        (
+            "float+int",
+            test(
+                lambda n: (R([n, n], dtype=torch.float32), I([n, n], dtype=torch.int32))
+            ),
+        ),
+        (
+            "double+long",
+            test(
+                lambda n: (R([n, n], dtype=torch.float64), I([n, n], dtype=torch.int64))
+            ),
+        ),
+        (
+            "fused addnorm",
+            test(
+                lambda n: (R(n, n), R(n, n), R(n, n), R(n, n)),
+                nnc=nnc_addnorm,
+                aten=eager_addnorm,
+            ),
+        ),
+        (
+            "fused addnorm (vs TS)",
+            test(
+                lambda n: (R(n, n), R(n, n), R(n, n), R(n, n)),
+                nnc=nnc_addnorm,
+                aten=ts_addnorm,
+            ),
+        ),
+        (
+            "fused addnorm out=",
+            test_out(
+                lambda n: (R(n, n), R(n, n), R(n, n), R(n, n)),
+                nnc=nnc_addnorm,
+                aten=inplace_addnorm,
+                out=lambda n: R(n, n),
+            ),
+        ),
+        (
+            "fused addnorm out= (vs TS)",
+            test_out(
+                lambda n: (R(n, n), R(n, n), R(n, n), R(n, n)),
+                nnc=nnc_addnorm,
+                aten=ts_ip_addnorm,
+                out=lambda n: R(n, n),
+            ),
+        ),
+        (
+            "fused addnorm backward",
+            test_backwards(
+                lambda n: (R(n, n), R(n, n, requires_grad=True), R(n, n), R(n, n)),
+                nnc=nnc_addnorm,
+                aten=eager_addnorm,
+            ),
+        ),
+        (
+            "fused addnorm backward (vs TS)",
+            test_backwards(
+                lambda n: (R(n, n), R(n, n, requires_grad=True), R(n, n), R(n, n)),
+                nnc=nnc_addnorm,
+                aten=ts_addnorm,
+            ),
+        ),
+    ]
+
+    df = pd.DataFrame(
+        np.stack([r for n, r in results]),
+        columns=[f"{n}x{n}".rjust(9) for n in SIZES],
+        index=[n for n, r in results],
+    )
+
+    if WRITE_CSV:
+        df.to_csv("../operator_authoring_results.csv")
+        print("wrote ../operator_authoring_results.csv")
+
+    print()
+    print("Speedups over aten")
+    pd.options.display.float_format = "{:.2f}x".format
+    print(df)
+
+
+if __name__ == "__main__":
+    main()

--- a/functorch/__init__.py
+++ b/functorch/__init__.py
@@ -22,6 +22,8 @@ from ._src.make_functional import functional_init, functional_init_with_buffers
 from ._src.python_key import wrap_key, PythonTensor, pythonkey_trace, make_fx, nnc_jit, make_nnc
 from ._src.nnc_compile import nnc_compile, get_ops
 from ._src.eager_compilation import compiled_function, compiled_module, tvm_compile, draw_joint_graph, default_partition
+from ._src.operator_authoring import pointwise_operator
+
 
 # Monkeypatching lol
 _old_cross_entropy = torch.nn.functional.cross_entropy

--- a/functorch/_src/operator_authoring.py
+++ b/functorch/_src/operator_authoring.py
@@ -1,0 +1,381 @@
+import copy
+import functools
+import inspect
+import itertools
+from typing import Callable, List, Union, Tuple, Optional
+
+import torch
+from torch import fx
+from torch._C import _te  # type: ignore[attr-defined]
+from functorch._C import CompileCache, CompileResult
+
+FOLD_ALIASES = True
+_SHAPE_TYPES = {"one", "other"}
+_STRIDE_TYPES = {"zero", "one", "contiguous", "transposed_contiguous", "as_arg"}
+_int = _te.ExprHandle.int
+
+
+def _argmax(x):
+    return int(torch.argmax(torch.LongTensor(x, device="cpu")))
+
+
+def _zero():
+    return _int(0)
+
+
+def _one():
+    return _int(1)
+
+
+def _num_args(fn: Callable):
+    return len(inspect.signature(fn).parameters)
+
+
+def _combine_dtype(a: torch.dtype, b: torch.dtype):
+    if a == b:
+        return a
+    # TODO(jansel): find a cleaner way to implement this
+    return (
+        torch.zeros(1, dtype=a, device="cpu") + torch.zeros(1, dtype=b, device="cpu")
+    ).dtype
+
+
+def _fx_replace_constants(fn: Callable, dtype: torch.dtype):
+    """Convert the constants in the user function to TensorExpr constants"""
+
+    def apply(arg):
+        if isinstance(arg, (int, float)):
+            return gm.graph.create_node("call_function", _create_constant, (arg, dtype))
+        return arg
+
+    gm: fx.GraphModule = fx.symbolic_trace(fn)
+    for node in list(gm.graph.nodes):
+        with gm.graph.inserting_before(node):
+            node.args = tuple(apply(a) for a in node.args)
+    gm.recompile()
+    return gm
+
+
+def _create_constant(value: Union[int, float], dtype: torch.dtype):
+    return _te.Cast.make(
+        dtype,
+        {int: _te.ExprHandle.int, float: _te.ExprHandle.double}[type(value)](value),
+    )
+
+
+class PointwiseCompiler(object):
+    def __init__(
+        self,
+        name: str,
+        module_name: str,
+        pointwise_fn: Callable,
+        spec: List,
+        result: CompileResult,
+    ):
+        self.name = name
+        self.module_name = module_name
+        self.pointwise_fn = pointwise_fn
+        self.spec = spec
+        self.result = result
+        self.ndim = max(x.ndim for x in spec)
+        self.shapes = [["one"] * (self.ndim - x.ndim) + x.shape for x in spec]
+        self.strides = [["zero"] * (self.ndim - x.ndim) + x.stride for x in spec]
+        self.shape_flags = copy.deepcopy(self.shapes)
+        self.stride_flags = copy.deepcopy(self.strides)
+        self.shape_args = [_te.VarHandle(torch.int32) for _ in range(self.ndim)]
+        self.shape_vars = list(self.shape_args)
+        self.iter_vars = [_te.VarHandle(torch.int32) for _ in range(self.ndim)]
+        self.stride_args: List[_te.VarHandle] = []
+        self.strides_from: List[Tuple[int, int]] = []
+        self.broadcasts: List[Tuple[int, int]] = []
+        self.output_order: List[int] = []
+
+        (self.device,) = list(set(x.device.type for x in spec))
+        # TODO(jansel): support meta tensors
+        self.compile_mode = {"cpu": "llvm", "cuda": "cuda"}[self.device]
+
+        if spec[-1].out:
+            self.dtype = spec[-1].dtype
+        else:
+            self.dtype = functools.reduce(_combine_dtype, [x.dtype for x in spec])
+
+        self.run()
+
+    def add_stride_arg(self, a, d):
+        var = _te.VarHandle(torch.int32)
+        self.stride_args.append(var)
+        self.strides_from.append((a, d))
+        return var
+
+    def replace_shape(self, a, d, expected, replacement):
+        if self.shapes[a][d] == expected:
+            self.shapes[a][d] = replacement()
+
+    def replace_stride(self, a, d, expected, replacement):
+        if self.strides[a][d] == expected:
+            self.strides[a][d] = replacement()
+
+    def error_checks(self):
+        spec = self.spec
+        (layout,) = list(set(x.layout for x in spec))
+        assert layout == torch.strided, "TODO: support other layouts"
+        assert [x.out for x in spec[:-1]] == [False] * (len(spec) - 1)
+        assert all(
+            shape_type in _SHAPE_TYPES for shape_type in itertools.chain(*self.shapes)
+        )
+        assert all(
+            stride_type in _STRIDE_TYPES
+            for stride_type in itertools.chain(*self.strides)
+        )
+
+    def make_backwards(self, index: int):
+        """
+        Compute the derivative of self.pointwise_fn with respect to input number index
+        """
+        # TODO(jansel): implement this without sympy
+        from sympy import symbols, diff  # type: ignore[import]
+
+        vars = symbols([f"v{i}" for i in range(1 + _num_args(self.pointwise_fn))])
+        backwards_expr = (
+            diff(self.pointwise_fn(*vars[:-1]), vars[index]) * vars[-1]
+        )  # chain rule
+        return _source_to_pointwise_operator(
+            f"lambda {','.join(map(str, vars))}: {backwards_expr}",
+            name=f"{self.name}.backwards{index}",
+            module_name=self.module_name,
+        )
+
+    def handle_autograd(self):
+        cnt = sum(int(x.requires_grad) for x in self.spec)
+        if cnt == 0:
+            return
+        assert all(
+            x.alias_group == 0 for x in self.spec
+        ), "TODO: support aliased backwards"
+
+        for i, spec in enumerate(self.spec):
+            if spec.requires_grad:
+                assert spec.alias_group == 0, "TODO: support aliased backwards"
+                assert spec.out == 0, "TODO: support autograd on out= ?"
+                for d in range(self.ndim):
+                    shape_types = {shape[d] for shape in self.shapes}
+                    assert (
+                        len(shape_types) == 1
+                    ), "TODO: support backwards for broadcasting"
+                self.result.set_backwards(i, self.make_backwards(i))
+
+    def compute_broadcasts_and_size_checks(self):
+        ndim = self.ndim
+        spec = self.spec
+        nargs = len(spec)
+        longest = _argmax([x.ndim for x in spec])
+        shapes = self.shapes
+        shape_from = [(longest, d) for d in range(ndim)]
+        for d in range(ndim):
+            first = None
+            for a in range(nargs):
+                if shapes[a][d] == "one":
+                    self.broadcasts.append((a, d))
+                elif shapes[a][d] == "other":
+                    if first is None:
+                        shape_from[d] = first = (a, d - (ndim - spec[a].ndim))
+                    else:
+                        self.result.add_shape_check(
+                            (first[0], first[1], a, d - (ndim - spec[a].ndim))
+                        )
+
+            if all(shapes[a][d] == "one" for a in range(nargs)):
+                self.shape_vars[d] = _one()
+
+        self.result.set_shape_from(shape_from)
+
+    def compute_output_order(self):
+        """
+        Decide on an iteration order (permutation) for the dimensions of the output
+        """
+        ndim = self.ndim
+        strides = self.strides
+        output_order = []
+        output_order_remaining = [[i] for i in range(ndim)]
+        # packed dims first
+        for d in reversed(range(ndim)):
+            if strides[0][d] == "one":
+                output_order.extend(output_order_remaining[d])
+                output_order_remaining[d].clear()
+        # swap the order for transposed
+        for d in reversed(range(ndim)):
+            if strides[0][d] == "transposed_contiguous":
+                output_order_remaining[d - 1].extend(output_order_remaining[d])
+                output_order_remaining[d].clear()
+        # rest contiguous
+        for d in reversed(range(ndim)):
+            output_order.extend(output_order_remaining[d])
+            output_order_remaining[d].clear()
+
+        assert not self.output_order
+        self.output_order = output_order
+        assert sorted(output_order) == list(range(ndim))
+
+    def compute_symbolic_shapes_and_strides(self):
+        nargs = len(self.spec)
+        ndim = self.ndim
+        shapes = self.shapes
+        strides = self.strides
+        for a in range(nargs):
+            # first fill in the terminal ones
+            for d in range(ndim):
+                self.replace_shape(a, d, "one", _one)
+                self.replace_shape(a, d, "other", lambda: self.shape_args[d])
+                self.replace_stride(a, d, "zero", _zero)
+                self.replace_stride(a, d, "one", _one)
+                if strides[a][d] == "as_arg":
+                    strides[a][d] = self.add_stride_arg(a, d)
+
+            # next the dependent ones
+            while any(isinstance(x, str) for x in strides[a]):
+                for d in reversed(range(ndim)):
+                    self.replace_stride(
+                        a, d, "contiguous", lambda: strides[a][d + 1] * shapes[a][d + 1]
+                    )
+                    if isinstance(strides[a][d], str):
+                        break
+                for d in range(ndim):
+                    self.replace_stride(
+                        a,
+                        d,
+                        "transposed_contiguous",
+                        lambda: strides[a][d - 1] * shapes[a][d - 1],
+                    )
+                    if isinstance(strides[a][d], str):
+                        break
+
+        for a, d in self.broadcasts:
+            strides[a][d] = _zero()
+
+        self.result.set_stride_args_from(self.strides_from)
+
+    def indexing(self, stride):
+        result = _zero()
+        for c, s in zip(self.iter_vars, stride):
+            result = result + c * s
+        return result
+
+    def compute_code(self):
+        bufs = [_te.BufHandle(s.dtype) for s in self.spec]
+        if not self.spec[-1].out:
+            options_from = [
+                i for i in range(len(self.spec)) if self.spec[i].dtype == self.dtype
+            ][0]
+            self.result.add_allocated_output(options_from, self.output_order)
+            bufs.append(_te.BufHandle(self.dtype))
+
+            self.shapes.append(list(self.shape_vars))
+            output_strides = [None] * self.ndim
+            next_stride = _one()
+            for i in self.output_order:
+                output_strides[i] = next_stride
+                next_stride *= self.shape_vars[i]
+            assert all((x is not None) for x in output_strides)
+            self.strides.append(output_strides)
+
+        bufs_args = list(bufs)
+
+        aliases = {}
+        for i, s in enumerate(self.spec):
+            assert s.alias_group >= 0, "TODO: support complex aliasing"
+            if s.alias_group > 0 and s.alias_group not in aliases:
+                aliases[s.alias_group] = i
+            elif s.alias_group > 0 and FOLD_ALIASES:
+                # BufHandle in buf_args is now ignored
+                bufs[i] = bufs[aliases[s.alias_group]]
+
+        input_bufs = bufs[:-1]
+        input_strides = self.strides[:-1]
+        output_bufs = bufs[-1:]
+        output_strides = self.strides[-1:]
+
+        inputs = [
+            _te.Cast.make(self.dtype, buf.load(self.indexing(stride)))
+            for buf, stride in zip(input_bufs, input_strides)
+        ]
+        val = _fx_replace_constants(self.pointwise_fn, self.dtype)(*inputs)
+        out = _te.Block(
+            [
+                buf.store(self.indexing(stride), val)
+                for buf, stride in zip(output_bufs, output_strides)
+            ]
+        )
+
+        loops: List[_te.For] = []
+        for i in self.output_order:
+            var = self.iter_vars[i]
+            size = self.shape_vars[i]
+            out = _te.For.make(var, _zero(), size, out)
+            loops.insert(0, out)
+
+        loopnest = _te.LoopNest(_te.Block([out]), output_bufs)
+
+        if self.device == "cuda" and loops:
+            flattened = _te.LoopNest.flatten(loops)
+            assert flattened
+            inner = _te.LoopNest.split_with_mask(flattened, 512)
+            assert inner
+            flattened.set_gpu_block_index(0)
+            inner.set_gpu_thread_index(0)
+        elif self.dtype == "llvm" and loops:
+            pass  # TODO(jansel): need a parallel CPU schedule
+
+        loopnest.prepare_for_codegen()
+        cg = _te.construct_codegen(
+            self.compile_mode,
+            loopnest.simplify(),
+            bufs_args + self.stride_args + self.shape_args,
+        )
+        self.result.set_code(cg)
+
+    def run(self):
+        self.error_checks()
+        self.handle_autograd()
+        self.compute_broadcasts_and_size_checks()
+        self.compute_output_order()
+        self.compute_symbolic_shapes_and_strides()
+        self.compute_code()
+
+
+class _CompileCache(CompileCache):
+    pass
+
+
+@functools.lru_cache(None)
+def _source_to_pointwise_operator(
+    fn_str: str, name: Optional[str] = None, module_name: Optional[str] = None
+):
+    """ Used when creating backwards() methods """
+    return pointwise_operator(eval(fn_str), name=name, module_name=module_name)
+
+
+def pointwise_operator(
+    fn: Callable, name: Optional[str] = None, module_name: Optional[str] = None
+):
+    """
+    Decorator to create a new pointwise operator.  The operator will be
+    JIT compiled for different dtypes/devices/layouts/etc -- but supports dynamic shapes.
+
+        @pointwise_operator
+        def add(a, b):
+            return a + b
+    """
+    name = name or fn.__name__
+    module_name = module_name or fn.__module__
+    args = [f"Tensor {name}" for name in inspect.signature(fn).parameters.keys()]
+    signature = f"{name}({', '.join(args)}, *, Tensor? out=None)"
+
+    def compile_fn(spec, result):
+        return PointwiseCompiler(str(name), str(module_name), fn, spec, result)
+
+    # This items are needed to support FX tracing
+    rv = _CompileCache(name, module_name, [signature], compile_fn, _num_args(fn))
+    rv.__name__ = name
+    rv.__qualname__ = name
+    rv.__module__ = module_name
+    return rv

--- a/functorch/csrc/CompileCache.cpp
+++ b/functorch/csrc/CompileCache.cpp
@@ -1,0 +1,826 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
+///
+/// This file implements a pretty complicated cache hierarchy to
+/// support fast lookup of cached compiled kernels based on input
+/// tensor properties.
+///
+/// To compile correct and efficient kernels, we need to know several
+/// details about the tensors involved (see SpecializationKey): the
+/// dtype, number of dimensions, contiguity and broadcasting in each
+/// dimension, etc.  We use these keys to look up the proper kernel,
+/// and compile a new version if we see a novel key.
+///
+/// To make the cache hit path as fast as possible, we create
+/// specialized caches based on the number of arguments (input and
+/// output) to the kernel, as well as the max number of tensor
+/// dimensions supported by the kernel.  All of this specialization is
+/// done with a bunch of template metaprogramming.
+///
+/// CompileCache
+///   --is a---> InOutSpecializedCache<NUM_IN, NUM_OUT>
+///   --has a--> ArgCountSpecializedCache<ArgCounts>
+///   --has a--> ArgAndDimSpecializedCache<ArgCounts, MAX_DIMS>
+///   --has a--> map<SpecializationKey<MAX_DIMS>,
+///                  CompileResult<ArgCounts, MAX_DIMS>>
+///
+/// With this structure, a SpecializationKey and CompileResult know
+/// exactly how many arguments and dimensions they have to deal with,
+/// so a bunch of checks can be done statically against fixed-size
+/// arrays rather than traversing dynamically allocated structures.
+/// This saves precious cycles in figuring out which kernel to
+/// launch!.
+///
+#include <functorch/csrc/CompileCache.h>
+#include <torch/csrc/autograd/custom_function.h>
+#include <torch/csrc/jit/python/pybind_utils.h>
+#include <torch/csrc/jit/tensorexpr/codegen.h>
+#include <torch/csrc/utils/pybind.h>
+
+using namespace torch::jit::tensorexpr;
+
+namespace {
+
+/// Record of thread-local state that changes operator behavior.
+struct LocalState {
+  c10::impl::LocalDispatchKeySet dispatchModifier;
+  bool gradModeEnabled;
+
+  at::DispatchKeySet apply(at::DispatchKeySet ks) const {
+    return (ks | dispatchModifier.included_) - dispatchModifier.excluded_;
+  }
+
+  LocalState()
+      : dispatchModifier(c10::impl::tls_local_dispatch_key_set()),
+        gradModeEnabled(at::GradMode::is_enabled()) {}
+};
+
+/// Helper to pack tensor (dtype, requires grad) into an 8-bit key.
+static uint8_t packFlags(const LocalState& state, const at::Tensor& v) {
+  static_assert(
+      static_cast<int>(at::ScalarType::NumOptions) < 128, "overflow possible");
+  at::ScalarType dtype = v.dtype().toScalarType();
+  bool requires_grad = state.gradModeEnabled && v.requires_grad();
+  return static_cast<uint8_t>(requires_grad) |
+      (static_cast<uint8_t>(dtype) << 1);
+}
+
+/// Per-tensor cache specialization key, templated on the number of
+/// tensor dims.  Records dtype, dispatch options, aliasing, and
+/// per-dim contiguity/broadcasting information.
+#pragma pack(push, 1)
+template <int MAX_DIMS>
+struct SpecializationKey {
+  /// Default constructor; does no initialization, use only for
+  /// declarations, e.g., std::array.
+  SpecializationKey() {} // NOLINT: intentionally not initialized
+
+  /// Construct a specialization key from a given TLS state and
+  /// Tensor.
+  // NOLINTNEXTLINE: intentionally not initializing dimflags_
+  SpecializationKey(
+      const LocalState& state,
+      const at::Tensor& v,
+      int8_t aliasGroup)
+      : flags_(packFlags(state, v)),
+        aliasGroup_(aliasGroup),
+        dispatchKey_(state.apply(v.key_set()).raw_repr()) {
+    initDimflags(v.sizes(), v.strides(), v.ndimension());
+  }
+
+  /// Compare key to other and return 0 if equal, <0 if key is less
+  /// than other, or >0 if key is greater than other.
+  bool operator<(const SpecializationKey<MAX_DIMS>& other) const {
+    static_assert(
+        sizeof(SpecializationKey<MAX_DIMS>) == 10 + MAX_DIMS,
+        "struct is not packed, memcmp requires no padding");
+    return memcmp(this, &other, sizeof(SpecializationKey<MAX_DIMS>)) < 0;
+  }
+
+  /// Get the dispatch key for this specialization.
+  at::DispatchKeySet dispatchKey() const {
+    return at::DispatchKeySet(at::DispatchKeySet::RAW, dispatchKey_);
+  }
+
+  /// Return vector of strings describing key sizes.
+  std::vector<std::string> shape() const {
+    std::vector<std::string> result;
+    for (int i = 0; i < MAX_DIMS; ++i) {
+      if ((dimflags_[i] & SIZE_MISSING) > 0) {
+        break;
+      }
+
+      if ((dimflags_[i] & SIZE_ONE) > 0) {
+        result.emplace_back("one");
+      } else {
+        result.emplace_back("other");
+      }
+    }
+    return result;
+  }
+
+  /// Return vector of strings describing key strides.
+  std::vector<std::string> stride() const {
+    std::vector<std::string> result;
+    for (int i = 0; i < MAX_DIMS; ++i) {
+      if ((dimflags_[i] & SIZE_MISSING) > 0) {
+        break;
+      }
+
+      if ((dimflags_[i] & STRIDE_ZERO) > 0) {
+        result.emplace_back("zero");
+      } else if ((dimflags_[i] & STRIDE_ONE) > 0) {
+        result.emplace_back("one");
+      } else if ((dimflags_[i] & STRIDE_CONTIGUOUS) > 0) {
+        result.emplace_back("contiguous");
+      } else if ((dimflags_[i] & STRIDE_TRANSPOSED_CONTIGUOUS) > 0) {
+        result.emplace_back("transposed_contiguous");
+      } else if ((dimflags_[i] & STRIDE_AS_ARG) > 0) {
+        result.emplace_back("as_arg");
+      } else {
+        TORCH_INTERNAL_ASSERT(false, "unknown stride properties");
+      }
+    }
+    return result;
+  }
+
+  /// Convert this specialization key to a python namedtuple.
+  py::object toPython(const at::Tensor& example, bool is_out) const {
+    // Create the python specialization key type (a namedtuple) lazily.
+    static py::object keyType = [] {
+      // create it lazily
+      py::object namedtuple =
+          py::module_::import("collections").attr("namedtuple");
+      return namedtuple(
+          "SpecializationKey",
+          "alias_group,ndim,dtype,device,layout,requires_grad,out,shape,stride");
+    }();
+    py::object ex = py::cast(example);
+    return keyType(
+        static_cast<int>(aliasGroup_),
+        ex.attr("ndim"),
+        ex.attr("dtype"),
+        ex.attr("device"),
+        ex.attr("layout"),
+        ex.attr("requires_grad"),
+        py::bool_(is_out),
+        shape(),
+        stride());
+  }
+
+ private:
+  /// Flag bits indicating tensor shape properties like contiguity and
+  /// broadcasting that are relevant for codegen.
+  enum DimFlags {
+    /// A leading dimension implicitly added by broadcasting.
+    SIZE_MISSING = 1 << 0,
+
+    /// Size == 1.
+    SIZE_ONE = 1 << 1,
+
+    /// Size > 1.
+    SIZE_OTHER = 1 << 2,
+
+    /// Stride == 0; broadcasting.
+    STRIDE_ZERO = 1 << 3,
+
+    /// Stride == 1; packed contiguously in memory.
+    STRIDE_ONE = 1 << 4,
+
+    /// Stride = Stride[i + 1] * Size[i + 1].
+    /// Used to collapse dimensions.
+    STRIDE_CONTIGUOUS = 1 << 5,
+
+    /// Stride = Stride[i - 1] * Size[i - 1].
+    /// Used to collapse dimensions in the other direction.
+    STRIDE_TRANSPOSED_CONTIGUOUS = 1 << 6, // stride[i-1] * sizes[i-1]
+
+    /// Stride must be provided as an argument.
+    STRIDE_AS_ARG = 1 << 7,
+  };
+
+  /// Initialize the shape flags for each dimension.
+  void initDimflags(
+      c10::IntArrayRef sizes,
+      c10::IntArrayRef strides,
+      int64_t ndims) {
+    // Pack all the properties for each dimension into a uint8.
+    for (int64_t dim = 0; dim < MAX_DIMS; ++dim) {
+      if (dim < ndims) {
+        uint8_t flag = (sizes[dim] == 1 ? SIZE_ONE : SIZE_OTHER);
+        if (strides[dim] == 0) {
+          flag |= STRIDE_ZERO;
+        } else if (strides[dim] == 1) {
+          flag |= STRIDE_ONE;
+        } else if (
+            dim + 1 < (int64_t)sizes.size() &&
+            strides[dim] == strides[dim + 1] * sizes[dim + 1]) {
+          flag |= STRIDE_CONTIGUOUS;
+        } else if (
+            dim > 0 && strides[dim] == strides[dim - 1] * sizes[dim - 1] &&
+            (dimflags_[dim - 1] & STRIDE_CONTIGUOUS) == 0) {
+          flag |= STRIDE_TRANSPOSED_CONTIGUOUS;
+        } else {
+          flag |= STRIDE_AS_ARG;
+        }
+        dimflags_[dim] = flag;
+      } else {
+        dimflags_[dim] = SIZE_MISSING | STRIDE_ZERO;
+      }
+    }
+  }
+
+ private:
+  /// Packed field with requires_grad and dtype.
+  uint8_t flags_;
+
+  /// Bits indicating whether there is aliasing in this group.
+  /// 0 = no aliasing
+  /// >0 = same data, strides, and shapes within group
+  /// <0 = overlapping storage madness
+  int8_t aliasGroup_;
+
+  /// DispatchKeySet includes device/layout.
+  uint64_t dispatchKey_;
+
+  /// Per-dimension shape flags.
+  // NOLINTNEXTLINE: C-style arrays
+  uint8_t dimflags_[MAX_DIMS];
+};
+#pragma pack(pop)
+
+/// Compiled kernel interface, used to set up kernel properties from
+/// python.  Implemented by template-specialized subclasses.
+struct CompileResultBase {
+  /// Destructor.
+  virtual ~CompileResultBase() = default;
+
+  /// Set contained code to cg.
+  virtual void setCode(const py::object& cg) = 0;
+
+  /// Set vector of (arg, dim) pairs that indicate from which argument/dimension
+  /// to extract the output size.
+  virtual void setShapeFrom(
+      const std::vector<std::pair<int, int>>& indices) = 0;
+
+  /// Set vector of (arg, dim) pairs that indicate from which argument/dimension
+  /// to extract the output stride.
+  virtual void setStrideArgsFrom(
+      const std::vector<std::pair<int, int>>& indices) = 0;
+
+  /// Add an output for this kernel with the associated options and storage
+  /// order.
+  virtual void addAllocatedOutput(
+      int options_from,
+      const std::vector<int>& storage_order) = 0;
+
+  /// Add a shape-checking constraint on the inputs.
+  virtual void addShapeCheck(const std::tuple<int, int, int, int>& indices) = 0;
+};
+
+/// Proxy object to bind compilation results to python.
+struct CompileResultProxy {
+  CompileResultBase* res;
+  explicit CompileResultProxy(CompileResultBase* r) : res(r) {}
+};
+
+/// Metaprogramming struct containing the number of arguments to a
+/// kernel.  Counts input, outputs that need to be allocated, and
+/// outputs that are provided by the caller.
+template <int NumIn, int NumOutAllocated, int NumOutGiven>
+struct ArgCounts {
+  static constexpr int numIn = NumIn;
+  static constexpr int numOutAllocated = NumOutAllocated;
+  static constexpr int numOutGiven = NumOutGiven;
+  static constexpr int numOut = NumOutAllocated + NumOutGiven;
+  static constexpr int numKeys = NumIn + NumOutGiven;
+  static constexpr int numBuffers = NumIn + NumOutAllocated + NumOutGiven;
+};
+
+/// Template container for a compiled kernel, specialized on the count
+/// of arguments (from specializing ArgCounts) and the maximum number
+/// of tensor dimensions.
+template <typename Counts, int MAX_DIMS>
+struct CompileResult : public CompileResultBase {
+  /// Set contained code to cg.
+  void setCode(const py::object& cg) {
+    pyCg_ = cg;
+    cg_ = cg.cast<CodeGen*>();
+  }
+
+  /// Set vector of (arg, dim) pairs that indicate from which argument/dimension
+  /// to extract the output size.
+  void setShapeFrom(const std::vector<std::pair<int, int>>& indices) {
+    assert(indices.shape() <= MAX_DIMS);
+    shapeFrom_ = indices;
+  }
+
+  /// Set vector of (arg, dim) pairs that indicate from which argument/dimension
+  /// to extract the output stride.
+  void setStrideArgsFrom(const std::vector<std::pair<int, int>>& indices) {
+    strideArgsFrom_ = indices;
+  }
+
+  /// Add an output for this kernel with the associated options and storage
+  /// order.
+  void addAllocatedOutput(
+      int optionsFrom,
+      const std::vector<int>& storageOrder) {
+    if (allocatedOutputs_.size() > 0) {
+      throw std::runtime_error("TODO: support more than one output");
+    }
+    allocatedOutputs_.emplace_back(std::make_pair(optionsFrom, storageOrder));
+  }
+
+  /// Add a shape-checking constraint on the inputs.
+  void addShapeCheck(const std::tuple<int, int, int, int>& indices) {
+    shapeChecks_.emplace_back(indices);
+  }
+
+  /// Call the cached kernel with the provided args.
+  void call(at::Tensor* args) {
+    for (const auto& ck : shapeChecks_) {
+      if (args[std::get<0>(ck)].size(std::get<1>(ck)) !=
+          args[std::get<2>(ck)].size(std::get<3>(ck))) {
+        // TODO(jansel): make this error message match aten
+        throw std::runtime_error(
+            "The size of tensor A must match the size of tensor B at non-singleton dimension X");
+      }
+    }
+
+    // NOLINTNEXTLINE: C-style arrays
+    void* callArgs[Counts::numBuffers + (Counts::numKeys + 1) * MAX_DIMS];
+    constexpr int allocatedArgsOffset = Counts::numKeys;
+    for (int i = 0; i < allocatedArgsOffset; ++i) {
+      callArgs[i] = args[i].data_ptr();
+    }
+
+    constexpr int strideArgsOffset =
+        allocatedArgsOffset + Counts::numOutAllocated;
+    for (int i : c10::irange(strideArgsFrom_.size())) {
+      auto& item = strideArgsFrom_[i];
+      callArgs[strideArgsOffset + i] =
+          // NOLINTNEXTLINE: const_cast
+          const_cast<int64_t*>(&args[item.first].strides()[item.second]);
+    }
+
+    int shapeArgsOffset = strideArgsOffset + strideArgsFrom_.size();
+    size_t numel = 1;
+    // NOLINTNEXTLINE: C-style arrays
+    int64_t shapes[MAX_DIMS];
+    int ndims = shapeFrom_.size();
+    for (int i = 0; i < ndims; ++i) {
+      shapes[i] = args[shapeFrom_[i].first].size(shapeFrom_[i].second);
+      numel *= shapes[i];
+      callArgs[shapeArgsOffset + i] = &shapes[i];
+    }
+
+    for (int i = 0; i < Counts::numOutAllocated; ++i) {
+      int optionsFrom = allocatedOutputs_[i].first;
+      auto& outputOrder = allocatedOutputs_[i].second;
+      // NOLINTNEXTLINE: C-style arrays
+      int64_t strides[MAX_DIMS];
+      int64_t nextStride = 1;
+      for (int j : outputOrder) {
+        strides[j] = nextStride;
+        nextStride *= shapes[j];
+      }
+      args[allocatedArgsOffset + i] = at::empty_strided(
+          c10::IntArrayRef(shapes, shapes + ndims),
+          c10::IntArrayRef(strides, strides + ndims),
+          args[optionsFrom].options());
+      callArgs[allocatedArgsOffset + i] =
+          args[allocatedArgsOffset + i].data_ptr();
+    }
+
+    // Release the GIL before calling the kernel, unless the kernel is
+    // tiny.
+    if (numel < 128) {
+      // TODO(jansel): should we also skip releasing the GIL on GPU?
+      cg_->call_with_numel(callArgs, numel);
+    } else {
+      py::gil_scoped_release release;
+      cg_->call_with_numel(callArgs, numel);
+    }
+  }
+
+  /// Check error conditions, e.g. mismatched input sizes.
+  void errorChecks() {
+    TORCH_CHECK(cg_ != nullptr);
+    TORCH_CHECK(shapeFrom_.size() <= MAX_DIMS);
+    TORCH_CHECK(allocatedOutputs_.size() == Counts::numOutAllocated);
+    TORCH_CHECK(
+        strideArgsFrom_.size() + shapeFrom_.size() <=
+        Counts::numKeys * MAX_DIMS + MAX_DIMS);
+    for (auto& item : shapeFrom_) {
+      TORCH_CHECK(item.first < Counts::numKeys);
+      TORCH_CHECK(item.second < MAX_DIMS);
+    }
+    for (auto& item : strideArgsFrom_) {
+      TORCH_CHECK(item.first < Counts::numKeys);
+      TORCH_CHECK(item.second < MAX_DIMS);
+    }
+    for (auto& item : shapeChecks_) {
+      TORCH_CHECK(std::get<0>(item) < Counts::numKeys);
+      TORCH_CHECK(std::get<1>(item) < MAX_DIMS);
+      TORCH_CHECK(std::get<2>(item) < Counts::numKeys);
+      TORCH_CHECK(std::get<3>(item) < MAX_DIMS);
+    }
+    for (auto& item : allocatedOutputs_) {
+      TORCH_CHECK(item.first < Counts::numKeys);
+      TORCH_CHECK(item.second.size() <= MAX_DIMS);
+    }
+  }
+
+ private:
+  /// Cached generated code.
+  CodeGen* cg_ = nullptr;
+
+  /// Python handle to generated code object, for refcounting.
+  py::object pyCg_;
+
+  /// Vector of pairs (arg, dim) indicating from which argument and
+  /// dimension to retrieve the shape for the output of this kernel.
+  std::vector<std::pair<int, int>> shapeFrom_;
+
+  /// Similar to shapeFrom_, but for strides.
+  std::vector<std::pair<int, int>> strideArgsFrom_;
+
+  /// Dimensions that need to be checked at runtime.
+  std::vector<std::tuple<int, int, int, int>> shapeChecks_;
+
+  /// Outputs to allocate.
+  std::vector<std::pair<int, std::vector<int>>> allocatedOutputs_;
+};
+
+/// Class template for a kernel cache specialized on the number of
+/// kernel args and max tensor dimensions.
+template <typename Counts, int MAX_DIMS>
+struct ArgAndDimSpecializedCache {
+  /// Construct a cache that compiles kernels using the supplied compileFn.
+  explicit ArgAndDimSpecializedCache(py::object compileFn)
+      : compileFn_(std::move(compileFn)) {}
+
+  /// Call the cached kernel matching args.
+  void call(at::Tensor* args) {
+    cachedCompile(computeCacheKey(args), args)->call(args);
+  }
+
+ private:
+  /// Array of keys used for specializing kernels in this cache.
+  using SpecializationKeys =
+      std::array<SpecializationKey<MAX_DIMS>, Counts::numKeys>;
+
+  /// Compiled kernel.
+  using CachedResult = CompileResult<Counts, MAX_DIMS>;
+
+  /// Array defining groups of aliased tensors.
+  using AliasGroups = std::array<int8_t, Counts::numKeys>;
+
+  /// Cache type mapping specialization keys to compiled kernels.
+  using Cache = std::map<SpecializationKeys, std::unique_ptr<CachedResult>>;
+
+  /// Compile a kernel for the given specializations.
+  std::unique_ptr<CachedResult> compile(
+      const SpecializationKeys& key,
+      at::Tensor* args) {
+    // Handle a cache miss by creating a new specialized implementation.
+    checkDispatchKeys(key);
+    auto cr = std::make_unique<CachedResult>();
+    std::vector<py::object> spec;
+    spec.reserve(Counts::numKeys);
+    for (int i = 0; i < Counts::numKeys; i++) {
+      spec.emplace_back(key[i].toPython(args[i], i >= Counts::numIn));
+    }
+    compileFn_(spec, CompileResultProxy(cr.get()));
+    cr->errorChecks();
+    return cr;
+  }
+
+  /// Retrieve a kernel from cache or compile if not found.
+  CachedResult* cachedCompile(const SpecializationKeys& key, at::Tensor* args) {
+    auto item = cache_.find(key); // protected by GIL
+    if (C10_LIKELY(item != cache_.end())) {
+      return item->second.get();
+    } else { // cache miss
+      auto iter = cache_.emplace(key, compile(key, args)).first;
+      return iter->second.get();
+    }
+  }
+
+  /// Verify that the current set of dispatch keys is supported by
+  /// this kernel, or throw an error.
+  void checkDispatchKeys(const SpecializationKeys& key) {
+    at::DispatchKeySet ks;
+    for (auto& item : key) {
+      ks = ks | item.dispatchKey();
+    }
+    constexpr at::DispatchKeySet supported = at::DispatchKeySet({
+        at::DispatchKey::CPU,
+        at::DispatchKey::CUDA,
+        at::DispatchKey::AutogradCPU,
+        at::DispatchKey::AutogradCUDA,
+        at::DispatchKey::BackendSelect,
+        at::DispatchKey::ADInplaceOrView,
+    });
+    ks = ks - supported;
+    if (C10_LIKELY(ks.empty())) {
+      return;
+    }
+    std::stringstream ss;
+    ss << "DispatchKeys not yet supported:";
+    for (at::DispatchKey k : ks) {
+      ss << " " << k;
+    }
+    throw std::runtime_error(ss.str());
+  }
+
+  /// Compute aliasing relationships between tensors a and b.
+  /// 0 means a/b don't alias.
+  /// 1 means a/b alias and are the same.
+  /// -1 means a/b have crazy aliasing overlaps.
+  int8_t computeAliasing(const at::Tensor& a, const at::Tensor& b) {
+    if (a.is_alias_of(b)) {
+      if (a.is_set_to(b)) {
+        return 1;
+      } else {
+        // TODO(jansel): check for non-overlapping and return 0 in cases where
+        // we can prove no aliasing. Possibly could take some logic from
+        // tensoriterator.
+        return -1;
+      }
+    } else {
+      return 0;
+    }
+  }
+
+  /// Compute aliasing groups: group of tensors that alias each other.
+  AliasGroups computeAliasGroups(at::Tensor* args) {
+    AliasGroups aliasGroups;
+    int8_t currentId = 0;
+    for (int i = 0; i < Counts::numKeys; ++i) {
+      aliasGroups[i] = 0;
+    }
+    for (int i = 0; i < Counts::numKeys; ++i) {
+      if (aliasGroups[i] == 0) {
+        for (int j = i + 1; j < Counts::numKeys; ++j) {
+          int8_t alias_type = computeAliasing(args[i], args[j]);
+          if (alias_type != 0) {
+            if (aliasGroups[i] == 0)
+              ++currentId;
+            aliasGroups[i] = currentId;
+            aliasGroups[j] = currentId * alias_type;
+          }
+        }
+      }
+    }
+    return aliasGroups;
+  }
+
+  /// Compute the set of specialization keys based on the inputs to
+  /// the kernel.
+  SpecializationKeys computeCacheKey(at::Tensor* args) {
+    LocalState state;
+    AliasGroups aliasGroups = computeAliasGroups(args);
+    SpecializationKeys key;
+    for (int i = 0; i < Counts::numKeys; ++i) {
+      key[i] = SpecializationKey<MAX_DIMS>(state, args[i], aliasGroups[i]);
+    }
+    return key;
+  }
+
+ private:
+  /// Storage for the cache.
+  Cache cache_;
+
+  /// The compilation function to apply when filling the cache.
+  py::object compileFn_;
+};
+
+/// Class template for kernel cache specialized on the number of args
+/// to the kernel, as given by a template parameter of type ArgCounts.
+template <typename Counts>
+struct ArgSpecializedCache {
+  /// Construct the cache with compilation function compileFn.
+  ArgSpecializedCache(const py::object& compileFn)
+      : cache2(compileFn), cache4(compileFn), cache8(compileFn) {}
+
+  /// Call the cached kernel with args.
+  void call(at::Tensor* args) {
+    // Fan out and and specialize on number of dimension buckets.
+    int64_t ndims = 0;
+    for (int i : c10::irange(Counts::numIn + Counts::numOutGiven)) {
+      ndims = std::max(args[i].dim(), ndims);
+    }
+    if (ndims <= 2) {
+      cache2.call(args);
+    } else if (ndims <= 4) {
+      cache4.call(args);
+    } else if (ndims <= 8) {
+      cache8.call(args);
+    } else {
+      throw std::runtime_error("TODO: handle more dims");
+    }
+  }
+
+ private:
+  /// Cache kernels with tensors having a max of 2 dims.
+  ArgAndDimSpecializedCache<Counts, 2> cache2;
+
+  /// Cache kernels with tensors having a max of 4 dims.
+  ArgAndDimSpecializedCache<Counts, 4> cache4;
+
+  /// Cache kernels with tensors having a max of 8 dims.
+  ArgAndDimSpecializedCache<Counts, 8> cache8;
+};
+
+/// Kernel cache interface.
+struct CompileCache {
+  /// Destructor.
+  virtual ~CompileCache() = default;
+
+  /// Call kernel using python objects.
+  virtual PyObject* pyCall(PyObject* args, PyObject* kwargs) = 0;
+
+  /// Call kernel using vector of tensors.
+  virtual at::Tensor call(const std::vector<at::Tensor>& args) = 0;
+
+  /// Get name of kernel.
+  virtual const std::string& getName() const = 0;
+};
+
+/// Specialized kernel cache templated on the number of input
+/// and output arguments.  Uses ArgSpecializedCache to further
+/// specialize on whether kernels are out variants.
+template <int NUM_IN, int NUM_OUT = 1>
+struct InOutSpecializedCache : public CompileCache {
+  constexpr static int NUM_ARGS = NUM_IN + NUM_OUT;
+  constexpr static int LAST_ARG = NUM_ARGS - 1;
+
+ public:
+  /// Construct a kernel cache for a kernel with given name,
+  /// module_name, and signatures, using a given compilation function.
+  InOutSpecializedCache(
+      std::string name,
+      std::string moduleName,
+      const std::vector<std::string>& signatures,
+      const py::object& compileFn)
+      : cache_(compileFn),
+        cacheOut_(compileFn),
+        parser_(signatures),
+        name_(std::move(name)),
+        moduleName_(std::move(moduleName_)) {
+    if (signatures.size() != 1) {
+      throw std::runtime_error("TODO: support overloaded signatures");
+    }
+  }
+
+  /// Returns name of kernel.
+  const std::string& getName() const {
+    return name_;
+  }
+
+  /// Call kernel using python objects.
+  PyObject* pyCall(PyObject* args, PyObject* kwargs) {
+    torch::ParsedArgs<NUM_ARGS> parsed_args;
+    torch::PythonArgs r = parser_.parse(args, kwargs, parsed_args);
+    bool presampled = false;
+    if (C10_UNLIKELY(r.has_torch_function())) {
+      py::object op = py::cast(static_cast<CompileCache*>(this));
+      return torch::handle_torch_function_no_python_arg_parser(
+          r.signature.overloaded_args,
+          args,
+          kwargs,
+          name_.c_str(),
+          op.ptr(),
+          moduleName_.c_str());
+    } else if (C10_UNLIKELY(
+                   at::hasCallbacks() &&
+                   at::shouldRunRecordFunction(&presampled))) {
+      throw std::runtime_error("TODO: implement record function");
+    } else {
+      at::Tensor tensorArgs[NUM_ARGS]; // NOLINT: c-style arrays
+      for (int i = 0; i < NUM_ARGS; ++i) {
+        tensorArgs[i] = r.tensor(i);
+      }
+      if (tensorArgs[LAST_ARG].defined()) {
+        cacheOut_.call(tensorArgs);
+      } else {
+        cache_.call(tensorArgs);
+      }
+      return THPVariable_Wrap(tensorArgs[LAST_ARG]);
+    }
+  }
+
+  /// Call kernel using vector of tensors.
+  at::Tensor call(const std::vector<at::Tensor>& args) {
+    if (C10_UNLIKELY(args.size() != NUM_IN)) {
+      throw std::runtime_error("wrong number of args");
+    }
+    at::Tensor tensorArgs[NUM_ARGS]; // NOLINT: c-style arrays
+    std::copy(args.begin(), args.end(), tensorArgs);
+    py::gil_scoped_acquire guard; // we protect our cache w/ GIL
+    cache_.call(tensorArgs);
+    return tensorArgs[LAST_ARG];
+  }
+
+ private:
+  /// Cache for kernel that allocates its output.
+  ArgSpecializedCache<ArgCounts<NUM_IN, NUM_OUT, 0>> cache_;
+
+  /// Cache for out-variant kernel, which has output provided.
+  ArgSpecializedCache<ArgCounts<NUM_IN, 0, NUM_OUT>> cacheOut_;
+
+  /// Parser for kernel args.
+  torch::PythonArgParser parser_;
+
+  /// Name of kernel.
+  std::string name_;
+
+  /// Module name of kernel.
+  std::string moduleName_;
+};
+
+/// Create a CompileCache with the given number of arguments.
+static CompileCache* createCompileCache(
+    const std::string& name,
+    const std::string& moduleName,
+    const std::vector<std::string>& sig,
+    const py::object& compileFn,
+    int numArgs) {
+  switch (numArgs) {
+    case 1:
+      return new InOutSpecializedCache<1>(name, moduleName, sig, compileFn);
+    case 2:
+      return new InOutSpecializedCache<2>(name, moduleName, sig, compileFn);
+    case 3:
+      return new InOutSpecializedCache<3>(name, moduleName, sig, compileFn);
+    case 4:
+      return new InOutSpecializedCache<4>(name, moduleName, sig, compileFn);
+    case 5:
+      return new InOutSpecializedCache<5>(name, moduleName, sig, compileFn);
+    case 6:
+      return new InOutSpecializedCache<6>(name, moduleName, sig, compileFn);
+    case 7:
+      return new InOutSpecializedCache<7>(name, moduleName, sig, compileFn);
+    case 8:
+      return new InOutSpecializedCache<8>(name, moduleName, sig, compileFn);
+    default:
+      throw std::runtime_error("TODO: support other arg counts");
+  }
+}
+} // namespace
+
+namespace at {
+namespace functorch {
+
+void initCompileCacheBindings(PyObject* module) {
+  py::handle te(module);
+
+  py::class_<CompileCache>(te, "CompileCache")
+      .def(py::init(&createCompileCache))
+      .def(
+          "__call__", [](CompileCache& self, py::args args, py::kwargs kwargs) {
+            return py::reinterpret_steal<py::object>(
+                self.pyCall(args.ptr(), kwargs.ptr()));
+          });
+
+  py::class_<CompileResultProxy>(te, "CompileResult")
+      .def(
+          "set_code",
+          [](CompileResultProxy& self, const py::object& cg) {
+            self.res->setCode(cg);
+          })
+      .def(
+          "add_shape_check",
+          [](CompileResultProxy& self,
+             const std::tuple<int, int, int, int>& indices) {
+            self.res->addShapeCheck(indices);
+          })
+      .def(
+          "set_shape_from",
+          [](CompileResultProxy& self,
+             const std::vector<std::pair<int, int>>& indices) {
+            self.res->setShapeFrom(indices);
+          })
+      .def(
+          "set_stride_args_from",
+          [](CompileResultProxy& self,
+             const std::vector<std::pair<int, int>>& indices) {
+            self.res->setStrideArgsFrom(indices);
+          })
+      .def(
+          "add_allocated_output",
+          [](CompileResultProxy& self,
+             int optionsFrom,
+             const std::vector<int>& storageOrder) {
+            self.res->addAllocatedOutput(optionsFrom, storageOrder);
+          });
+}
+
+} // namespace functorch
+} // namespace at

--- a/functorch/csrc/CompileCache.h
+++ b/functorch/csrc/CompileCache.h
@@ -1,0 +1,17 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+#pragma once
+
+#include <torch/csrc/utils/pybind.h>
+
+namespace at {
+namespace functorch {
+
+/// Initialize python bindings for kernel compilation cache.
+void initCompileCacheBindings(PyObject* module);
+
+} // namespace functorch
+} // namespace at

--- a/functorch/csrc/init.cpp
+++ b/functorch/csrc/init.cpp
@@ -13,6 +13,7 @@
 #include <functorch/csrc/VmapTransforms.h>
 #include <functorch/csrc/BatchedFallback.h>
 #include <functorch/csrc/BatchRulesHelper.h>
+#include <functorch/csrc/CompileCache.h>
 
 
 namespace at {
@@ -252,4 +253,5 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("get_unwrapped", &at::functorch::get_unwrapped);
   m.def("maybe_get_level", &at::functorch::maybe_get_level);
   m.def("maybe_get_bdim", &at::functorch::maybe_get_bdim);
+  at::functorch::initCompileCacheBindings(m.ptr());
 }

--- a/test/test_operator_authoring.py
+++ b/test/test_operator_authoring.py
@@ -1,0 +1,140 @@
+import torch
+import unittest
+
+import numpy as np
+
+import torch
+from torch import fx
+from functorch import pointwise_operator
+from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.jit_utils import JitTestCase
+import unittest
+
+LLVM_ENABLED = torch._C._llvm_enabled()
+HAS_SYMPY = False
+try:
+    import sympy
+
+    HAS_SYMPY = True
+except ImportError:
+    pass
+
+
+def pointwise_fn(a, b):
+    return (a + b) * 42
+
+
+nnc_pointwise_fn = pointwise_operator(pointwise_fn)
+
+
+@pointwise_operator
+def custom1(a):
+    return a + 1.0
+
+
+@pointwise_operator
+def custom2(a):
+    return a + 2.0
+
+
+class TorchFunctionExample(object):
+    def __torch_function__(self, func, types, args=(), kwargs=None):
+        assert func in (nnc_pointwise_fn, torch.Tensor.add)
+        assert all(issubclass(t, (torch.Tensor, TorchFunctionExample)) for t in types)
+        return torch.zeros_like(args[0])
+
+
+class TestOperatorAuthoringCPU(JitTestCase):
+    device = "cpu"
+
+    def rand(self, *args, dtype=torch.float32, **kwargs):
+        return torch.randint(0, 100, args, dtype=dtype, device=self.device, **kwargs)
+
+    def check(self, *args):
+        result_aten = pointwise_fn(*args)
+        result_nnc = nnc_pointwise_fn(*args)
+        self.assertEqual(result_nnc.dtype, result_aten.dtype)
+        self.assertEqual(result_nnc.size(), result_aten.size())
+        self.assertEqual(result_nnc.stride(), result_aten.stride())
+        self.assertEqual(result_nnc.requires_grad, result_aten.requires_grad)
+        torch.testing.assert_allclose(result_aten, result_nnc)
+
+    def test_broadcast1(self):
+        self.check(self.rand(8, 16), self.rand(1))
+
+    def test_broadcast2(self):
+        self.check(self.rand(8, 1), self.rand(1, 8))
+
+    def test_transposed1(self):
+        self.check(self.rand(7, 3), self.rand(3, 7).transpose(0, 1))
+
+    def test_transposed2(self):
+        self.check(self.rand(8, 16).transpose(0, 1), self.rand(8, 16).transpose(0, 1))
+
+    def test_slice1(self):
+        self.check(self.rand(20, 20, 2)[:8, :16, 0], self.rand(8, 16))
+
+    def test_slice2(self):
+        self.check(self.rand(8, 16, 2)[:, :, 0], self.rand(8, 16, 2)[:, :, 0])
+
+    def test_issue57611(self):
+        self.check(self.rand(1, 32, 32, 2), self.rand(2, 1, 1, 2))
+
+    def test_float_double(self):
+        self.check(self.rand(8, 16), self.rand(8, 16, dtype=torch.float64))
+
+    def test_int_long(self):
+        self.check(
+            self.rand(8, 16, dtype=torch.int32), self.rand(1, 1, dtype=torch.int64)
+        )
+
+    def test_float_int(self):
+        self.check(
+            self.rand(8, 16, dtype=torch.float32), self.rand(8, 16, dtype=torch.int32)
+        )
+
+    @unittest.skipIf(not HAS_SYMPY, "currently requires sympy")
+    def test_requires_grad(self):
+        self.check(self.rand(4, 2), self.rand(4, 2, requires_grad=True))
+
+    @unittest.skipIf(not HAS_SYMPY, "currently requires sympy")
+    def test_backwards(self):
+        def grads(fn):
+            a = self.rand(4, 2, requires_grad=True)
+            b = self.rand(4, 2, requires_grad=True)
+            c = self.rand(4, 2)
+            d = self.rand(4, 2)
+            fn(fn(a, fn(b, c)), d).sum().backward()
+            return a.grad, b.grad
+
+        a1, b1 = grads(pointwise_fn)
+        a2, b2 = grads(nnc_pointwise_fn)
+        torch.testing.assert_allclose(a1, a2)
+        torch.testing.assert_allclose(b1, b2)
+
+    def test_torch_function(self):
+        self.check(self.rand(10), TorchFunctionExample())
+
+    def test_fx_trace(self):
+        def example(x):
+            return custom1(custom2(x))
+
+        graph = fx.symbolic_trace(example)
+        self.assertIn("custom1", graph.code)
+        self.assertIn("custom2", graph.code)
+        x = torch.randn(8, device=self.device)
+        torch.testing.assert_allclose(x + 3, graph(x))
+
+
+class TestOperatorAuthoringGPU(TestOperatorAuthoringCPU):
+    device = "cuda"
+
+
+if not LLVM_ENABLED:
+    TestOperatorAuthoringCPU = None  # noqa: F811
+
+if not torch.cuda.is_available():
+    TestOperatorAuthoringGPU = None  # noqa: F811
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
The main problem was missing handle_torch_function_no_python_arg_parser from the main API.  This PR also adds the handling for backward.