### PR TITLE
no_grad fix

### DIFF
--- a/functorch/csrc/DynamicLayer.cpp
+++ b/functorch/csrc/DynamicLayer.cpp
@@ -33,7 +33,7 @@ class DynamicLayerStackHolder : public c10::DebugInfoBase {
   DynamicLayerStackHolder() {}
   virtual ~DynamicLayerStackHolder() {}
 
-  std::vector<DynamicLayer> dynamicLayerStack = { DynamicLayer(DispatchKey::Autograd, 1) };
+  std::vector<DynamicLayer> dynamicLayerStack = { DynamicLayer(DispatchKey::Autograd, 1, nullopt, true) };
 };
 
 thread_local std::shared_ptr<DynamicLayerStackHolder> kDynamicLayerStack;
@@ -117,13 +117,16 @@ static int64_t pushDynamicLayer(DynamicLayer&& dynamic_layer) {
   return layerId;
 }
 
-static int64_t pushDynamicLayer(DispatchKey key, optional<int64_t> batch_size = nullopt) {
+static int64_t pushDynamicLayer(
+    DispatchKey key,
+    optional<int64_t> batch_size = nullopt,
+    optional<bool> prev_grad_mode = nullopt) {
   auto& dynamicLayerStack = dynamicLayerStackAccessor();
   TORCH_INTERNAL_ASSERT(key != DispatchKey::Undefined);
   TORCH_INTERNAL_ASSERT(key != DispatchKey::Batched);
 
   auto layerId = 1 + dynamicLayerStack.size();
-  dynamicLayerStack.emplace_back(key, layerId, batch_size);
+  dynamicLayerStack.emplace_back(key, layerId, batch_size, prev_grad_mode);
 
   if (layerId == 2) {
     // std::cout << "DynamicLayer on" << std::endl;
@@ -134,10 +137,16 @@ static int64_t pushDynamicLayer(DispatchKey key, optional<int64_t> batch_size = 
   return layerId;
 }
 
-int64_t initAndPushDynamicLayer(DispatchKey key, optional<int64_t> batch_size) {
-  auto layerId = pushDynamicLayer(key, batch_size);
+int64_t initAndPushDynamicLayer(
+    DispatchKey key,
+    optional<int64_t> batch_size,
+    optional<bool> prev_grad_mode) {
+  auto layerId = pushDynamicLayer(key, batch_size, prev_grad_mode);
   auto& data = getGlobalDynmetaData();
   TORCH_INTERNAL_ASSERT(data.find(layerId) == data.end());
+  if (key == DispatchKey::Autograd) {
+    TORCH_INTERNAL_ASSERT(prev_grad_mode.has_value());
+  }
   data[layerId] = std::make_shared<bool>(true);
   return layerId;
 }
@@ -374,7 +383,6 @@ struct WithoutTop {
     pushDynamicLayer(std::move(layer_));
   }
 
-  bool prev_grad_enabled_;
   DynamicLayer layer_;
 };
 
@@ -393,6 +401,11 @@ struct SaveLocalDispatchKeySet {
 void dynamicLayerBackFallback(const c10::OperatorHandle& op, torch::jit::Stack* stack) {
   auto cur_level = getDynamicLayerStack().back().layerId();
   auto cur_key = getDynamicLayerStack().back().key();
+
+  optional<bool> prev_grad_mode = getDynamicLayerStack().back().prevGradMode();
+  if (cur_key == DispatchKey::Autograd) {
+    TORCH_INTERNAL_ASSERT(prev_grad_mode.has_value());
+  }
 
   auto unwrap = [&](const Tensor& tensor) {
     if (!tensor.defined()) {
@@ -457,7 +470,13 @@ void dynamicLayerBackFallback(const c10::OperatorHandle& op, torch::jit::Stack* 
   c10::impl::tls_set_dispatch_key_included(kDynamicLayerBackModeKey, true);
 
   // Re-dispatch
-  op.callBoxed(stack);
+  if (cur_key == DispatchKey::Autograd && *prev_grad_mode == false) {
+    // See NOTE [grad and vjp interaction with no_grad]
+    c10::AutoGradMode guard(*prev_grad_mode);
+    op.callBoxed(stack);
+  } else {
+    op.callBoxed(stack);
+  }
 
   // Step 4, 5, 6
   if (cur_key == DispatchKey::Autograd) {

--- a/functorch/csrc/DynamicLayer.h
+++ b/functorch/csrc/DynamicLayer.h
@@ -17,21 +17,43 @@ namespace at {
 namespace functorch {
 
 struct TORCH_API DynamicLayer {
-  DynamicLayer(DispatchKey key, int64_t layerId, optional<int64_t> batchSize = nullopt): key_(key), layerId_(layerId), batchSize_(batchSize) {}
+  DynamicLayer(
+      DispatchKey key,
+      int64_t layerId,
+      optional<int64_t> batchSize = nullopt,
+      optional<bool> prev_grad_mode = nullopt):
+    key_(key), layerId_(layerId), batchSize_(batchSize), prevGradMode_(prev_grad_mode)
+  {
+    if (key_ == DispatchKey::Autograd) {
+      TORCH_INTERNAL_ASSERT(prev_grad_mode.has_value());
+    }
+  }
 
   DispatchKey key() const { return key_; }
   int64_t layerId() const { return layerId_; }
+  // Only valid for vmap
   int64_t batchSize() const {
     TORCH_INTERNAL_ASSERT(batchSize_);
     return *batchSize_;
   }
+  // only valid for grad-based transforms
+  optional<bool> prevGradMode() const {
+    return prevGradMode_;
+  }
  private:
   DispatchKey key_;
   int64_t layerId_;
+
+  // Honestly these should be a union or some extendable metadata class.
+  // Not doing that for now because I don't think we'll use this mechanism for very long.
   optional<int64_t> batchSize_;
+  optional<bool> prevGradMode_;
 };
 
-TORCH_API int64_t initAndPushDynamicLayer(DispatchKey key, optional<int64_t> batch_size = nullopt);
+TORCH_API int64_t initAndPushDynamicLayer(
+    DispatchKey key,
+    optional<int64_t> batch_size = nullopt,
+    optional<bool> prev_grad_mode = nullopt);
 TORCH_API DynamicLayer popDynamicLayerAndDeleteMetadata();
 TORCH_API c10::optional<DynamicLayer> maybeCurrentDynamicLayer();
 TORCH_API const std::vector<DynamicLayer>& getDynamicLayerStack();

--- a/functorch/csrc/init.cpp
+++ b/functorch/csrc/init.cpp
@@ -158,7 +158,9 @@ bool dump_tensor(const Tensor& self) {
 }
 
 int64_t _grad_increment_nesting() {
-  return initAndPushDynamicLayer(at::DispatchKey::Autograd);
+  // See NOTE [grad and vjp interaction with no_grad]
+  bool prev_grad_mode = c10::GradMode::is_enabled();
+  return initAndPushDynamicLayer(at::DispatchKey::Autograd, nullopt, prev_grad_mode);
 }
 
 int64_t _grad_decrement_nesting() {


### PR DESCRIPTION
Fixes https://github.com/facebookresearch/functorch/issues/13

Case 1: grad gets called inside torch.no_grad.

- grad should ignore torch.no_grad because it's "creating a new level of
autograd above the current level"
- Another way to think about this is that grad(f) is a "function
transform": its result should not be affected by context managers that
are outside of the function f

Case 2: torch.no_grad gets called inside `grad`
- grad should respect torch.no_grad

See NOTE [grad and vjp interaction with no_grad] for implementation
strategy. It unfortunately involves a mode.

Test Plan:
- Many tests