### PR TITLE
add aminmax batching rule

### DIFF
--- a/functorch/csrc/BatchRulesReduceOps.cpp
+++ b/functorch/csrc/BatchRulesReduceOps.cpp
@@ -281,6 +281,13 @@ std::tuple<Tensor, optional<int64_t>, Tensor, optional<int64_t>> aminmax_batchin
   }
 
   std::tie(min, max) = at::aminmax(self_, dim, keep_dim);
+
+  if (logical_rank == 0 && self_.device().is_cuda()) {
+    // behaviour diverges between cpu and cuda
+    // reference: https://github.com/pytorch/pytorch/issues/64008
+    min = min.squeeze(-1);
+    max = max.squeeze(-1);
+  }
   return std::make_tuple(min, 0, max, 0);
 }
 

--- a/functorch/csrc/BatchRulesReduceOps.cpp
+++ b/functorch/csrc/BatchRulesReduceOps.cpp
@@ -255,6 +255,35 @@ std::tuple<Tensor,optional<int64_t>> _log_softmax_backward_batch_rule(
   return std::make_tuple(at::_log_softmax_backward_data(grad_output_, output_, dim, input_dtype), 0);
 }
 
+std::tuple<Tensor, optional<int64_t>, Tensor, optional<int64_t>> aminmax_batching_rule(
+    const Tensor &self, optional<int64_t> self_bdim, optional<int64_t> dim, bool keep_dim)
+{
+  Tensor min, max;
+  if (!self_bdim.has_value())
+  {
+    std::tie(min, max) = at::aminmax(self, dim, keep_dim);
+    return std::make_tuple(min, self_bdim, max, self_bdim);
+  }
+
+  auto self_ = moveBatchDimToFront(self, self_bdim);
+  auto logical_rank = rankWithoutBatchDim(self_, self_bdim);
+  if (logical_rank == 0) {
+    self_ = self_.unsqueeze(-1);
+  }
+
+  if (dim.has_value()) {
+    dim = maybe_wrap_dim(dim.value(), logical_rank) + 1;
+  } else {
+    // flatten the input except for batch-dim
+    auto bsize = self.size(0);
+    self_ = self.view({bsize, -1});
+    dim = 1;
+  }
+
+  std::tie(min, max) = at::aminmax(self_, dim, keep_dim);
+  return std::make_tuple(min, 0, max, 0);
+}
+
 TORCH_LIBRARY_IMPL(aten, FT_BATCHED_KEY, m) {
   REDUCTION_BOXED(_fft_r2c);
   REDUCTION_BOXED(_fft_c2r);
@@ -306,6 +335,7 @@ TORCH_LIBRARY_IMPL(aten, FT_BATCHED_KEY, m) {
   REDUCTION_BOXED(var_mean.correction);
   REDUCTION_BOXED(_log_softmax);
   REDUCTION_BOXED_ARGS(rot90, 2);
+  VMAP_SUPPORT("aminmax", aminmax_batching_rule);
 
   VMAP_SUPPORT("_log_softmax_backward_data", _log_softmax_backward_batch_rule);
   VMAP_SUPPORT("_softmax_backward_data", _softmax_backward_batch_rule);

--- a/test/test_vmap.py
+++ b/test/test_vmap.py
@@ -3023,7 +3023,6 @@ class TestVmapOperatorsOpInfo(TestCase):
     @ops(functorch_lagging_op_db + additional_op_db, allowed_dtypes=(torch.float,))
     @skipOps('TestVmapOperatorsOpInfo', 'test_op_has_batch_rule', {
         # xfail('__getitem__'),
-        xfail('aminmax'),
         xfail('broadcast_to'),
         xfail('cdist'),
         xfail('complex'),


### PR DESCRIPTION
`aminmax` has a different behavior compared to other reduction ops for scalar tensor.

```python
t = torch.randn(())

result = torch.aminmax(t, dim=0, keepdim=True)
print(result[0].shape, result[1].shape)

result = torch.sum(t, dim=0, keepdim=True)
print(result.shape)
```

Output
```
torch.Size([1]) torch.Size([1])
torch.Size([])
```

Due to this we can't use `REDUCTION_BOXED_ARGS` as is (due to the following lines).
https://github.com/facebookresearch/functorch/blob/17f407c9faea3ec5f953b9afb17d7c8c7e6f34fb/functorch/csrc/BatchRulesReduceOps.cpp#L162-L164

For this reason, have added a batching rule. Other option would be to update `REDUCTION_BOXED_ARGS` to accommodate this case.